### PR TITLE
Arbitrary class training in Pytorch #5

### DIFF
--- a/templates/Image classification_PyTorch/code-template.py.jinja
+++ b/templates/Image classification_PyTorch/code-template.py.jinja
@@ -180,7 +180,19 @@ model = models.{{ model_func }}(pretrained={{ pretrained }})
 model = model.to(device)
 loss_func = nn.{{ loss }}()
 optimizer = optim.{{ optimizer }}(model.parameters(), lr=lr)
+num_classes = {{ num_classes }}
 
+{% if not num_classes == 1000 %}
+{% if "resnet" in model_func %}
+model.fc = torch.nn.Linear(in_features = model.fc.in_features, out_features=num_classes, bias=True)
+{% endif %}
+{% if "alexnet" in model_func or "vgg" in model_func %}
+model.classifier[-1] = torch.nn.Linear(in_features = model.classifier[-1].in_features, out_features=num_classes, bias=True)
+{% endif %}
+{% if "densenet" in model_func %}
+model.classifier = torch.nn.Linear(in_features = model.classifier.in_features, out_features=num_classes, bias=True)
+{% endif %}
+{% endif %}
 
 {{ header("Training") }}
 # Set up pytorch-ignite trainer and evaluator.

--- a/templates/Image classification_PyTorch/code-template.py.jinja
+++ b/templates/Image classification_PyTorch/code-template.py.jinja
@@ -177,11 +177,7 @@ test_loader = preprocess(test_data, "test")
 {{ header("Model") }}
 # Set up model, loss, optimizer.
 model = models.{{ model_func }}(pretrained={{ pretrained }})
-model = model.to(device)
-loss_func = nn.{{ loss }}()
-optimizer = optim.{{ optimizer }}(model.parameters(), lr=lr)
 num_classes = {{ num_classes }}
-
 {% if not num_classes == 1000 %}
 {% if "resnet" in model_func %}
 model.fc = torch.nn.Linear(in_features = model.fc.in_features, out_features=num_classes, bias=True)
@@ -193,6 +189,10 @@ model.classifier[-1] = torch.nn.Linear(in_features = model.classifier[-1].in_fea
 model.classifier = torch.nn.Linear(in_features = model.classifier.in_features, out_features=num_classes, bias=True)
 {% endif %}
 {% endif %}
+model = model.to(device)
+loss_func = nn.{{ loss }}()
+optimizer = optim.{{ optimizer }}(model.parameters(), lr=lr)
+
 
 {{ header("Training") }}
 # Set up pytorch-ignite trainer and evaluator.

--- a/templates/Image classification_PyTorch/sidebar.py
+++ b/templates/Image classification_PyTorch/sidebar.py
@@ -63,6 +63,10 @@ def show():
                 unsafe_allow_html=True,
             )
 
+        # Number of dense units in the final layer
+        st.write("## Classes")
+        inputs["num_classes"] = st.number_input("Num Classes", 1, None, 1000)
+
         st.write("## Input data")
         inputs["data_format"] = st.selectbox(
             "What best describes your input data?", ("Numpy arrays", "Image files")

--- a/templates/Image classification_PyTorch/test-inputs.yml
+++ b/templates/Image classification_PyTorch/test-inputs.yml
@@ -14,6 +14,7 @@ visualization_tool:
 pretrained: False
 loss: CrossEntropyLoss
 optimizer: Adam
+num_classes: 10
 lr: 0.001
 batch_size: 128
 num_epochs: 1


### PR DESCRIPTION
### Summary

This PR adds support for declaring number of clasees for Image Classification Pytorch models.


### Details

* Adds a parameter in the sidebar below the "Use pre-trained model" checkbox
* Default value is 1000 (what torchvision uses)
* If pre-trained is True, imagenet weights are loaded and last fc layer is redefined


### Checklist

- [X] all tests are passing (see README.md on how to run tests)
- [ ] if you created a new template: it contains a file `test-inputs.yml`, which specifies a few input values to test the code template (the test is then automatically run by pytest)
- [X] you formatted all code with [black](https://github.com/psf/black)
- [X] you checked all new functionality live, i.e. in the running web app
- [X] any generated code is formatted nicely, both in .py and in .ipynb ("nicely" = comparable to the existing templates)
- [X] you added comments in your code that explain what it does
- [X] the PR explains in detail what's new