### PR TITLE
Add pre-commit hook for Black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-subtests
 black
+pre-commit


### PR DESCRIPTION
### Summary

Thanks for the interesting package, I can see it softening the burden of writing lots of boiler-plate code for standard-ish modeling tasks.

I've noticed code formatting with black is enforced in [`CONTRIBUTING.md`](https://github.com/jrieke/traingenerator/blob/main/CONTRIBUTING.md). Might be a good idea to add a pre-commit hook to take that out of the equation when reviewing pull requests.

### Details

### Checklist

- [x] all tests are passing (see README.md on how to run tests)
- [ ] if you created a new template: it contains a file `test-inputs.yml`, which specifies a few input values to test the code template (the test is then automatically run by pytest)
- [ ] you formatted all code with [black](https://github.com/psf/black)
- [ ] you checked all new functionality live, i.e. in the running web app
- [ ] any generated code is formatted nicely, both in .py and in .ipynb ("nicely" = comparable to the existing templates)
- [ ] you added comments in your code that explain what it does
- [x] the PR explains in detail what's new