### PR TITLE
Add Mlflow tracking

### DIFF
--- a/templates/Image classification_PyTorch/code-template.py.jinja
+++ b/templates/Image classification_PyTorch/code-template.py.jinja
@@ -47,6 +47,10 @@ from tensorboardX import SummaryWriter
 from aim import Session
 {% elif visualization_tool == "Weights & Biases" %}
 import wandb
+{% elif visualization_tool == "MLflow" %}
+import mlflow
+from ignite.contrib.handlers import MLflowLogger
+import ignite
 {% endif %}
 {% if checkpoint %}
 from pathlib import Path
@@ -121,6 +125,10 @@ wandb.init(
 )
 {% elif visualization_tool == "comet.ml" %}
 experiment = Experiment("{{ comet_api_key }}"{% if comet_project %}, project_name="{{ comet_project }}"{% endif %})
+{% elif visualization_tool == "MLflow" %}
+mlflow_logger = MLflowLogger()
+{% elif new_mlflow_exp %}
+mlflow.set_experiment("{{ mlflow_experiment_name }}")
 {% endif %}
 {% if checkpoint %}
 checkpoint_dir = Path(f"checkpoints/{experiment_id}")
@@ -302,6 +310,9 @@ def log_epoch(trainer):
         {% elif visualization_tool == "comet.ml" %}
         experiment.log_metric(f"{name}_loss", metrics["loss"])
         experiment.log_metric(f"{name}_accuracy", metrics["accuracy"])
+        {% elif visualization_tool == "MLflow" %}
+        mlflow.log_metric(f"{name}_loss", metrics["loss"], step=epoch)
+        mlflow.log_metric(f"{name}_accuracy", metrics["accuracy"], step=epoch)
         {% endif %}
 
     # Train data.
@@ -322,6 +333,25 @@ def log_epoch(trainer):
     print("-" * 80)
     print()
 
+{% if visualization_tool == "MLflow" %}
+# Log info on GPU only if available
+if use_cuda:
+    cuda_params = {
+        "cuda version": torch.version.cuda,
+        "device name": torch.cuda.get_device_name
+    }
+else: cuda_params = {}
+
+mlflow_logger.log_params({
+    "batch_size": batch_size,
+    "model": model.__class__.__name__,
+    "learning_rate": lr,
+    "pytorch version": torch.__version__,
+    "ignite version": ignite.__version__,
+    **cuda_params
+})
+{% endif %}
+
 {# TODO: Maybe use this instead: https://pytorch.org/ignite/handlers.html#ignite.handlers.ModelCheckpoint #}
 {% if checkpoint %}
 @trainer.on(Events.EPOCH_COMPLETED)
@@ -333,4 +363,6 @@ def checkpoint_model(trainer):
 trainer.run(train_loader, max_epochs=num_epochs)
 {% if visualization_tool == "Weights & Biases" %}
 wandb.finish()
+{% elif visualization_tool == "MLflow" %}
+mlflow.end_run()
 {% endif %}

--- a/templates/Image classification_PyTorch/code-template.py.jinja
+++ b/templates/Image classification_PyTorch/code-template.py.jinja
@@ -6,6 +6,7 @@
 #
 {%- endif %}
  pip install numpy torch torchvision pytorch-ignite{% if visualization_tool == "Tensorboard" %} tensorboardX tensorboard{% endif %}{% if visualization_tool == "Weights & Biases" %} wandb{% endif %}{% if visualization_tool == "comet.ml" %} comet_ml{% endif %}{% if visualization_tool == "Aim" %} aim{% endif %}
+{% if visualization_tool == "MLflow "%} apache-airflow {% endif %}
 {% if visualization_tool == "Weights & Biases" %}
 
 

--- a/templates/Image classification_PyTorch/sidebar.py
+++ b/templates/Image classification_PyTorch/sidebar.py
@@ -157,7 +157,14 @@ def show():
         st.write("## Visualizations")
         inputs["visualization_tool"] = st.selectbox(
             "How to log metrics?",
-            ("Not at all", "Tensorboard", "Aim", "Weights & Biases", "comet.ml", "MLflow"),
+            (
+                "Not at all",
+                "Tensorboard",
+                "Aim",
+                "Weights & Biases",
+                "comet.ml",
+                "MLflow",
+            ),
         )
         if inputs["visualization_tool"] == "Aim":
             inputs["aim_experiment"] = st.text_input("Experiment name (optional)")

--- a/templates/Image classification_PyTorch/sidebar.py
+++ b/templates/Image classification_PyTorch/sidebar.py
@@ -62,7 +62,10 @@ def show():
             inputs["model_func"] = MODELS[model]
 
         inputs["num_classes"] = st.number_input(
-            "How many classes/output units?", 1, None, 1000,
+            "How many classes/output units?",
+            1,
+            None,
+            1000,
         )
         st.markdown(
             "<sup>Default: 1000 classes for training on ImageNet</sup>",
@@ -154,7 +157,7 @@ def show():
         st.write("## Visualizations")
         inputs["visualization_tool"] = st.selectbox(
             "How to log metrics?",
-            ("Not at all", "Tensorboard", "Aim", "Weights & Biases", "comet.ml"),
+            ("Not at all", "Tensorboard", "Aim", "Weights & Biases", "comet.ml", "MLflow"),
         )
         if inputs["visualization_tool"] == "Aim":
             inputs["aim_experiment"] = st.text_input("Experiment name (optional)")
@@ -173,6 +176,16 @@ def show():
         elif inputs["visualization_tool"] == "Tensorboard":
             st.markdown(
                 "<sup>Logs are saved to timestamped dir in `./logs`. View by running: `tensorboard --logdir=./logs`</sup>",
+                unsafe_allow_html=True,
+            )
+        elif inputs["visualization_tool"] == "MLflow":
+            inputs["new_mlflow_exp"] = st.checkbox("Create a new experiment")
+            if inputs["new_mlflow_exp"]:
+                inputs["mlflow_experiment_name"] = st.text_input(
+                    "MLflow experiment name"
+                )
+            st.markdown(
+                "<sup>By default, Logs are saved to `mlruns/` folder",
                 unsafe_allow_html=True,
             )
 

--- a/templates/Image classification_PyTorch/test-inputs.yml
+++ b/templates/Image classification_PyTorch/test-inputs.yml
@@ -18,6 +18,7 @@ visualization_tool:
   - Not at all
   - Tensorboard
   - Aim
+  - MLflow
   # TODO: Find a way to add comet.ml here, without requiring API key.
 num_classes:
   - 10

--- a/templates/Image classification_scikit-learn/code-template.py.jinja
+++ b/templates/Image classification_scikit-learn/code-template.py.jinja
@@ -27,6 +27,8 @@ import zipfile
 {% if visualization_tool == "Tensorboard" %}
 from tensorboardX import SummaryWriter
 from datetime import datetime
+{% elif visualization_tool == "MLflow" %}
+import mlflow
 {% endif %}
 
 {% if data_format == "Numpy arrays" %}
@@ -78,6 +80,12 @@ writer = SummaryWriter(logdir=f"logs/{experiment_id}")
 {% elif visualization_tool == "comet.ml" %}
 # Set up logging.
 experiment = Experiment("{{ comet_api_key }}"{% if comet_project %}, project_name="{{ comet_project }}"{% endif %})
+
+{% elif new_mlflow_exp %} mlflow.set_experiment("{{ mlflow_experiment_name }}")
+{% elif visualization_tool == "MLflow" %} 
+mlflow.start_run()
+run = mlflow.active_run()
+run_id = run.info.run_id
 
 {% endif %}
 
@@ -148,6 +156,8 @@ def evaluate(data, name):
     writer.add_scalar(f"{name}_accuracy", acc)
     {% elif visualization_tool == "comet.ml" %}
     experiment.log_metric(f"{name}_accuracy", acc)
+    {% elif visualization_tool == "MLflow" %}
+    mlflow.log_metric(f"{name}_accuracy", acc)
     {% endif %}
 
 # Train on train_data.
@@ -157,3 +167,7 @@ model.fit(*processed_train_data)
 evaluate(processed_train_data, "train")
 evaluate(processed_val_data, "val")
 evaluate(processed_test_data, "test")
+
+{% if visualization_tool == "MLflow" %}
+mlflow.end_run()
+{% endif %}

--- a/templates/Image classification_scikit-learn/code-template.py.jinja
+++ b/templates/Image classification_scikit-learn/code-template.py.jinja
@@ -5,7 +5,8 @@
 {%- else %}
 #
 {%- endif %}
- pip install numpy sklearn{% if data_format == "Image files" %} torchvision{% endif %}{% if visualization_tool == "Tensorboard" %} tensorboardX{% endif %}{% if visualization_tool == "comet.ml" %} comet_ml{% endif %}
+pip install numpy sklearn{% if data_format == "Image files" %} torchvision{% endif %}{% if visualization_tool == "Tensorboard" %} tensorboardX{% endif %}{% if visualization_tool == "comet.ml" %} comet_ml{% endif %}
+{% if visualization_tool == "MLflow "%} apache-airflow {% endif %}
 {% if notebook %}
 
 

--- a/templates/Image classification_scikit-learn/sidebar.py
+++ b/templates/Image classification_scikit-learn/sidebar.py
@@ -72,7 +72,7 @@ def show():
 
         st.write("## Visualizations")
         inputs["visualization_tool"] = st.selectbox(
-            "How to log metrics?", ("Not at all", "Tensorboard", "comet.ml")
+            "How to log metrics?", ("Not at all", "Tensorboard", "comet.ml", "MLflow")
         )
         if inputs["visualization_tool"] == "comet.ml":
             # TODO: Add a tracker how many people click on this link.
@@ -82,6 +82,16 @@ def show():
         elif inputs["visualization_tool"] == "Tensorboard":
             st.markdown(
                 "<sup>Logs are saved to timestamped dir in `./logs`. View by running: `tensorboard --logdir=./logs`</sup>",
+                unsafe_allow_html=True,
+            )
+        elif inputs["visualization_tool"] == "MLflow":
+            inputs["new_mlflow_exp"] = st.checkbox("Create a new experiment")
+            if inputs["new_mlflow_exp"]:
+                inputs["mlflow_experiment_name"] = st.text_input(
+                    "MLflow experiment name"
+                )
+            st.markdown(
+                "<sup>By default, Logs are saved to `mlruns/` folder",
                 unsafe_allow_html=True,
             )
 

--- a/templates/Image classification_scikit-learn/test-inputs.yml
+++ b/templates/Image classification_scikit-learn/test-inputs.yml
@@ -10,5 +10,6 @@ scale_mean_std:
 visualization_tool:
   - Not at all
   - Tensorboard
+  - MLflow
 resize_pixels: 28
 crop_pixels: 28


### PR DESCRIPTION
### Summary
As mentioned in #17, adding training run and experiment tracking capabilities using [Mlflow][1] for the following templates:
- `templates/Image classification_PyTorch`
- `templates/Image classification_scikit-learn`

### Details
This PR implements basic metric/model info logging features. As a second logical next step, model artifact logging (checkpoints and final model) will be added.

### Checklist

- [x] all tests are passing (see README.md on how to run tests)
- [ ] if you created a new template: it contains a file `test-inputs.yml`, which specifies a few input values to test the code template (the test is then automatically run by pytest)
- [x] you formatted all code with [black](https://github.com/psf/black)
- [x] you checked all new functionality live, i.e. in the running web app
- [x] any generated code is formatted nicely, both in .py and in .ipynb ("nicely" = comparable to the existing templates)
- [ ] you added comments in your code that explain what it does
- [x] the PR explains in detail what's new

[1]: https://www.mlflow.org/